### PR TITLE
Flask end point and OpenShift YAML files to list all projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,156 @@
+## Openshift Reporting Backend
+
+OpenShift Reporting uses metering operator as backend.
+
+More Details about Metering Operator [Metering Operator](https://docs.openshift.com/container-platform/4.3/metering/metering-installing-metering.html)
+
+### Prerequisites 
+
+1. OpenShift Account as Cluster Administrator
+
+2. Locally running OpenShift Cluster [CRC](https://developers.redhat.com/products/codeready-containers). Refer this [CRC for Openshift Reporting Backend]
+
+3. Enable Alerting,monitoring, telemetry on CRC cluster using following commands
+
+```bash
+oc scale --replicas=1 statefulset --all -n openshift-monitoring; 
+oc scale --replicas=1 deployment --all -n openshift-monitoring
+```
+
+
+### Installation
+
+#### Metering Operator Installation for local OCP cluster. 
+
+``` bash
+# Login as the Cluster Administrator
+ 
+a. Create a namespace openshift-metering 
+b. Label the namespace with `openshift.io/cluster-monitoring=true`
+c. Search Red Hat Metering under Operator Hub and Click Install. 
+d. Wait until Metering Operator pods are up and Running successfully.
+
+# Output after these steps
+NAME                                  READY   STATUS              RESTARTS   AGE
+
+metering-operator-68dd64cfb6-pxh8v    2/2     Running             0          2m49s
+```
+
+#### Installing Metering Stack / Metering Configuration for local OCP cluser
+
+Understanding [Metering Configuration](https://docs.openshift.com/container-platform/4.3/metering/configuring_metering/metering-about-configuring.html#metering-about-configuring)
+
+At a minimum, you need to configure persistent storage and configure the Hive metastore.[Refer Samples](https://docs.openshift.com/container-platform/4.3/metering/configuring_metering/metering-about-configuring.html#metering-about-configuring)
+
+
+```bash
+$ oc project openshift-metering
+$ oc create -f https://raw.githubusercontent.com/dburugupalli/SSMT/feature-1/openshift-metering-templates/configuration-templates/metering-configuration.yaml
+ 
+# Wait until Componenets of metering stack are installed like hive metastore, presto database and 
+# reporting operator 
+
+$ oc -n openshift-metering get pods
+NAME                                 READY   STATUS    RESTARTS   AGE
+hive-metastore-0                     2/2     Running   14         7d15h
+hive-server-0                        3/3     Running   21         7d15h
+metering-operator-86b95669bb-njp4q   2/2     Running   14         7d15h
+presto-coordinator-0                 2/2     Running   8          7d2h
+reporting-operator-978687d9c-vkzrl   2/2     Running   27         7d15h
+# to view custom resource definations
+$ oc get crd | grep metering
+hivetables.metering.openshift.io                            2020-05-19T04:34:42Z
+meteringconfigs.metering.openshift.io                       2020-05-19T04:34:42Z
+prestotables.metering.openshift.io                          2020-05-19T04:34:42Z
+reportdatasources.metering.openshift.io                     2020-05-19T04:34:42Z
+reportqueries.metering.openshift.io                         2020-05-19T04:34:42Z
+reports.metering.openshift.io                               2020-05-19T04:34:42Z
+storagelocations.metering.openshift.io                      2020-05-19T04:34:42Z
+```
+
+#### Verify Metering Stack / Configuration for local OCP cluster 
+
+```bash
+oc get reportdatasources -n openshift-metering | grep -v raw
+```
+Metering stack creates sample instances of reportdatasource and reportqueries custom resources. 
+
+### Creating Reports 
+
+For Now, lets use the pre-defined reportdatasources and reportqueries to generate our first report
+
+```bash
+$ oc project openshift-metering
+$ oc create -f https://raw.githubusercontent.com/dburugupalli/SSMT/feature-1/openshift-metering-templates/reports-templates/namespace-cpu-request-hourly.yaml
+$ meteringRoute="$(oc get routes metering -o jsonpath='{.spec.host}')"
+$ echo "$meteringRoute"
+$ token="$(oc whoami -t)"
+$ reportName=namespace-cpu-request-hourly
+$ reportFormat=json
+# Change reportForma=csv to get output in csv format
+$ curl --insecure -H "Authorization: Bearer ${token}" "https://${meteringRoute}/api/v1/reports/get?name=${reportName}&namespace=openshift-metering&format=$reportFormat"
+```
+To view reports on the terminal. 
+
+### Defining Report-Query and ReportDataSources to acheive specific functionality
+
+#### What if we want to define our own reportquery and reportdatasource custom resources, to achieve specific functionality ? 
+
+Yes, We can define our own reportquery and reportdatasource
+
+##### Define Reportdatasource custom resource, 
+
+it contains PromQL queries. We can write our own promQL queries to create datasource and achieve our functionality 
+
+```bash
+...
+spec:
+  prometheusMetricsImporter:
+    query: |
+      sum(kube_pod_container_resource_requests_cpu_cores) by (pod, namespace, node)
+.....
+```
+
+##### Define ReportQuery custom resource
+
+if you inspect one reportquery custom resource, it contains SQL like queries. We can write our own SQL queries to achieve specific purpose. Presto Database provides functionality to execute SQL like queries. Presto has a dependency on Hive, and uses Hive for keeping metadata about the data Presto is working with.
+
+```bash 
+oc edit reportquery pod-cpu-request
+```
+```bash 
+# output
+# it takes various parameters as inputs, if we observe the yaml template
+....
+  query: |
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+      pod,
+      namespace,
+      node,
+      sum(pod_request_cpu_core_seconds) as pod_request_cpu_core_seconds
+    FROM {| dataSourceTableName .Report.Inputs.PodCpuRequestRawDataSourceName |}
+    WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+    AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+    AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+    AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+    GROUP BY namespace, pod, node
+    ORDER BY namespace, pod, node ASC, pod_request_cpu_core_seconds DESC
+...
+```
+Above queries gets the data in descending order. Lets, Define SQL query to get data in ascending order4
+
+To get the data in ascending order, execute the following commands 
+
+```bash 
+oc delete reportquery pod-cpu-request
+oc create -f https://raw.githubusercontent.com/dburugupalli/SSMT/feature-1/openshift-metering-templates/reportquery-templates/create-pod-cpu-request-reportquery.yaml
+```
+When the report is created, data will be populated in ascending order
+
+## Contributing
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+Please make sure to update tests as appropriate.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+from flask import Flask
+from flask import request
+from flask.json import jsonify
+import signal
+import os
+import sys
+import json
+import requests
+import datetime
+
+app = Flask(__name__)
+OPENSHIFT_TOKEN = os.environ.get("OS_OPENSHIFT_TOKEN")
+FLASK_APP_URL = 'http://' + str(os.environ.get("HOST","localhost")) +':'+str(os.environ.get("PORT", 8000))
+METERING_ROUTE_LIST_ALL_PROJECTS = os.environ.get("OS_LIST_ALL_PROJECTS_URL")
+
+@app.route('/list_projects')
+def list_projects():
+    now = datetime.datetime.utcnow()
+    period_end = now.strftime("%Y-%m-%d"+"T"+"%H:00:00"+"Z")
+    hour = int(now.strftime("%H"))
+    hour = str(hour -1)
+    period_start = now.strftime("%Y-%m-%d"+"T") + hour + "00:00Z"
+    url = FLASK_APP_URL + '/list_projects/' + period_start + '/'+ period_end
+    r = requests.get(url, verify=False)
+    return r.json()
+
+@app.route('/list_projects/<period_start>/<period_end>')
+def get_project_reports(period_start, period_end):
+    if OPENSHIFT_TOKEN == False:
+        return "Please set environment variables, execute config.sh"
+    headers = {'Authorization': 'Bearer ' + OPENSHIFT_TOKEN,
+    'Accept': 'application/json', 'Content-Type': 'application/json'}
+    url = METERING_ROUTE_LIST_ALL_PROJECTS
+    r = requests.get(url, headers=headers, verify=False)
+    input_json = r.text
+    input_dict = json.loads(input_json)
+    print(input_dict)
+    output_dict = [x for x in input_dict if x['period_start'] == period_start]
+    data = [x for x in output_dict if x['period_start'] == period_start]
+    return jsonify(data)
+
+def signal_term_handler(signal, frame):
+    app.logger.warn('got SIGTERM')
+    sys.exit(0)
+
+if __name__ == '__main__':
+    signal.signal(signal.SIGTERM, signal_term_handler)
+    app.run(host=str(os.environ.get("HOST","localhost")), port=int(os.environ.get("PORT", 8000)))

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,3 @@
+export OS_LIST_ALL_PROJECTS_URL="http://metering-openshift-metering.apps-crc.testing/api/v1/reports/get?name=list-all-projects-v1-hourly&namespace=openshift-metering&format=json"
+export OS_OPENSHIFT_TOKEN = "$(oc whoami -t)"
+

--- a/openshift-metering-templates/configuration-templates/metering-configuration-node-selector.yaml
+++ b/openshift-metering-templates/configuration-templates/metering-configuration-node-selector.yaml
@@ -1,0 +1,28 @@
+# If you want to run the metering components on specific sets of nodes, 
+# then you can set nodeSelectors on each component to control where each component of metering is scheduled.
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: "operator-metering"
+spec:
+  reporting-operator:
+    spec:
+      nodeSelector:
+        "node-role.kubernetes.io/infra": "true"
+
+  presto:
+    spec:
+      coordinator:
+        nodeSelector:
+          "node-role.kubernetes.io/infra": "true"
+      worker:
+        nodeSelector:
+          "node-role.kubernetes.io/infra": "true"
+  hive:
+    spec:
+      metastore:
+        nodeSelector:
+          "node-role.kubernetes.io/infra": "true"
+      server:
+        nodeSelector:
+          "node-role.kubernetes.io/infra": "true"

--- a/openshift-metering-templates/configuration-templates/metering-configuration.yaml
+++ b/openshift-metering-templates/configuration-templates/metering-configuration.yaml
@@ -1,0 +1,57 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: operator-metering
+  namespace: openshift-metering
+spec:
+  presto:
+    spec:
+      coordinator:
+        resources:
+          limits:
+            cpu: 3.5
+            memory: 5Gi
+          requests:
+            cpu: 2
+            memory: 3Gi
+    #   worker:
+    #     replicas: 0
+    #     resources:
+    #       limits:
+    #         cpu: 8
+    #         memory: 8Gi
+    #       requests:
+    #         cpu: 4
+    #         memory: 2Gi
+  storage:
+    hive:
+      sharedPVC:
+        claimName: metering-nfs
+        createPVC: true
+        size: 10Gi
+      type: sharedPVC
+    type: hive
+    # uncomment the hive configuration lines, to use default values provided by the metering operators.
+    # hive:
+    #     spec:
+    #       metastore:
+    #         resources:
+    #           limits:
+    #             cpu: 4
+    #             memory: 2Gi
+    #           requests:
+    #             cpu: 500m
+    #             memory: 650Mi
+    #         storage:
+    #           class: null
+    #           create: true
+    #           size: 5Gi
+    #       server:
+    #         resources:
+    #           limits:
+    #             cpu: 1
+    #             memory: 1Gi
+    #           requests:
+    #             cpu: 500m
+    #             memory: 500Mi
+    

--- a/openshift-metering-templates/reportdatasources-templates/create-pod-cpu-request-datasource.yaml
+++ b/openshift-metering-templates/reportdatasources-templates/create-pod-cpu-request-datasource.yaml
@@ -1,0 +1,13 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+# example file where we can view the prometheus queries 
+apiVersion: metering.openshift.io/v1
+kind: ReportDataSource
+metadata:
+  name: pod-request-cpu-cores
+  namespace: openshift-metering
+spec:
+  prometheusMetricsImporter:
+    query: |
+      sum(kube_pod_container_resource_requests_cpu_cores) by (pod, namespace, node)

--- a/openshift-metering-templates/reportquery-templates/create-pod-cpu-request-reportquery.yaml
+++ b/openshift-metering-templates/reportquery-templates/create-pod-cpu-request-reportquery.yaml
@@ -1,0 +1,54 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+# SQL query to get pod-cpu-request in ascending order
+apiVersion: metering.openshift.io/v1
+kind: ReportQuery
+metadata:
+  name: pod-cpu-request
+  namespace: openshift-metering
+spec:
+  columns:
+  - name: period_start
+    type: timestamp
+    unit: date
+  - name: period_end
+    type: timestamp
+    unit: date
+  - name: pod
+    type: varchar
+    unit: kubernetes_pod
+  - name: namespace
+    type: varchar
+    unit: kubernetes_namespace
+  - name: node
+    type: varchar
+    unit: kubernetes_node
+  - name: pod_request_cpu_core_seconds
+    type: double
+    unit: cpu_core_seconds
+  inputs:
+  - name: ReportingStart
+    type: time
+  - name: ReportingEnd
+    type: time
+  - default: pod-cpu-request-raw
+    name: PodCpuRequestRawDataSourceName
+    type: ReportDataSource
+  query: |
+  SELECT
+    timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+    timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+    pod,
+    namespace,
+    node,
+    sum(pod_request_cpu_core_seconds) as pod_request_cpu_core_seconds
+  FROM {| dataSourceTableName .Report.Inputs.PodCpuRequestRawDataSourceName |}
+  WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+  AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+  AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+  AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+  GROUP BY namespace, pod, node
+  ORDER BY namespace, pod, node ASC, pod_request_cpu_core_seconds ASC
+
+

--- a/openshift-metering-templates/reportquery-templates/list-all-projects-v1-reportquery.yaml
+++ b/openshift-metering-templates/reportquery-templates/list-all-projects-v1-reportquery.yaml
@@ -1,0 +1,72 @@
+apiVersion: metering.openshift.io/v1
+kind: ReportQuery
+metadata:
+  name: list-all-projects-v1
+  namespace: openshift-metering
+spec:
+  columns:
+    - name: period_start
+      type: timestamp
+      unit: date
+    - name: period_end
+      type: timestamp
+      unit: date
+    - name: namespace
+      type: varchar
+      unit: kubernetes_namespace
+    - name: pod
+      type: varchar
+      unit: kubernetes_pod
+    - name: node
+      type: varchar
+      unit: kubernetes_node
+    - name: pod_usage_cpu_core_seconds
+      type: double
+      unit: cpu_core_seconds
+  inputs:
+    - name: ReportingStart
+      type: time
+    - name: ReportingEnd
+      type: time
+    - name: NamespaceCPUUsageReportName
+      type: Report
+    - default: pod-cpu-usage-raw
+      name: PodCpuUsageRawDataSourceName
+      type: ReportDataSource
+  query: >
+    SELECT
+      timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}' AS period_start,
+      timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}' AS period_end,
+    {|- if .Report.Inputs.NamespaceCPUUsageReportName |}
+      namespace,'namespace_pods',node,
+      sum(pod_usage_cpu_core_seconds) as pod_usage_cpu_core_seconds
+    FROM {| .Report.Inputs.NamespaceCPUUsageReportName | reportTableName |}
+
+    WHERE period_start  >= timestamp '{| default .Report.ReportingStart
+    .Report.Inputs.ReportingStart | prestoTimestamp |}'
+
+    AND period_end <= timestamp '{| default .Report.ReportingEnd
+    .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+
+    GROUP BY namespace, node
+
+    {|- else |}
+      namespace,'namespace_pods',node,
+      sum(pod_usage_cpu_core_seconds) as pod_usage_cpu_core_seconds
+    FROM {| dataSourceTableName .Report.Inputs.PodCpuUsageRawDataSourceName |}
+
+    WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart
+    .Report.Inputs.ReportingStart | prestoTimestamp |}'
+
+    AND "timestamp" < timestamp '{| default .Report.ReportingEnd
+    .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+
+    AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart |
+    prometheusMetricPartitionFormat |}'
+
+    AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd |
+    prometheusMetricPartitionFormat |}'
+
+    GROUP BY namespace, node
+
+    {|- end |}

--- a/openshift-metering-templates/reports-templates/list-all-projects-v1-hourly.yaml
+++ b/openshift-metering-templates/reports-templates/list-all-projects-v1-hourly.yaml
@@ -1,0 +1,9 @@
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: list-all-projects-v1-hourly
+  namespace: openshift-metering
+spec:
+  query: list-all-projects-v1
+  schedule:
+    period: hourly

--- a/openshift-metering-templates/reports-templates/list-all-projects-v1-once.yaml
+++ b/openshift-metering-templates/reports-templates/list-all-projects-v1-once.yaml
@@ -1,0 +1,10 @@
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: list-all-projects-v1-once
+  namespace: openshift-metering
+spec:
+  query: list-all-projects-v1
+  reportingEnd: '2020-12-30T23:59:59Z'
+  reportingStart: '2020-05-01T00:00:00Z'
+  runImmediately: true

--- a/openshift-metering-templates/reports-templates/namespace-cpu-request-hourly.yaml
+++ b/openshift-metering-templates/reports-templates/namespace-cpu-request-hourly.yaml
@@ -1,0 +1,9 @@
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: namespace-cpu-request-hourly
+  namespace: openshift-metering
+spec:
+  query: namespace-cpu-request
+  schedule:
+    period: hourly

--- a/openshift-metering-templates/reports-templates/namespace-cpu-request-once.yaml
+++ b/openshift-metering-templates/reports-templates/namespace-cpu-request-once.yaml
@@ -1,0 +1,10 @@
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: namespace-cpu-request-once
+  namespace: openshift-metering
+spec:
+  query: namespace-cpu-request
+  reportingEnd: "2020-12-30T23:59:59Z"
+  reportingStart: "2020-05-01T00:00:00Z"
+  runImmediately: true

--- a/openshift-metering-templates/reports-templates/pod-cpu-request-hourly.yaml
+++ b/openshift-metering-templates/reports-templates/pod-cpu-request-hourly.yaml
@@ -1,0 +1,9 @@
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: pod-cpu-request-hourly
+  namespace: openshift-metering
+spec:
+  query: pod-cpu-request
+  schedule:
+    period: hourly

--- a/openshift-metering-templates/reports-templates/pod-cpu-usage-once.yaml
+++ b/openshift-metering-templates/reports-templates/pod-cpu-usage-once.yaml
@@ -1,0 +1,10 @@
+apiVersion: metering.openshift.io/v1
+kind: Report
+metadata:
+  name: pod-cpu-usage-once
+  namespace: openshift-metering
+spec:
+  query: pod-cpu-usage
+  reportingEnd: "2020-12-30T23:59:59Z"
+  reportingStart: "2020-05-21T00:00:00Z"
+  runImmediately: true

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-Commit Test


### PR DESCRIPTION
-- **app.py** 

- Flask end point contains two routes, to list all projects 

```bash
APP_URL/list_projects -- to list projects of last 1 hour on to the home page

APP_URL/list_projects//<period_start>/<period_end> -- to list the projects within the specified URL
```
-- **OpenShift YAML Templates**

- list-all-projects-v1-reportquery.yaml (version 1 SQL Query to query presto database)  
- list-all-projects-v1-once.yaml (Version 1 to report the hourly projects) 
```bash
Can be used to testing if reporting is working
```
- list-all-projects-v1-hourly.yaml(is used to list all the hourly projects) 
-- config.sh 
 Shell script to set the environment variables.
