### PR TITLE
metering-configuration-role-binding.yaml file

### DIFF
--- a/Documentation/Installing_crc.md
+++ b/Documentation/Installing_crc.md
@@ -55,7 +55,7 @@ crc ip # This will give the Virtual Machine IP address
 #### Error in starting Monitoring, Telemetry and Alerting
 ```bash
 oc get clusterversion version -ojsonpath='{range .spec.overrides[*]}{.name}{"\n"}{end}' | nl -v 0
-
+#  Replace the unmanged-operator-index to [0 cluster-monitoring-operator]
 oc patch clusterversion/version --type='json' -p '[{"op":"remove", "path":"/spec/overrides/<unmanaged-operator-index>"}]' -oyaml
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ More Details about Metering Operator [Metering Operator](https://docs.openshift.
 oc scale --replicas=1 statefulset --all -n openshift-monitoring; 
 oc scale --replicas=1 deployment --all -n openshift-monitoring
 ```
+Note: if the above commands donot work, Please refer [CRC for Openshift Reporting Backend](https://github.com/dburugupalli/SSMT/blob/feature-1/Documentation/Installing_crc.md) under 'Error in starting Monitoting, Telemetry and Alerting Section'
 
 
 ### Installation

--- a/openshift-metering-templates/configuration-templates/metering-configuration-auth-role-binding.yaml
+++ b/openshift-metering-templates/configuration-templates/metering-configuration-auth-role-binding.yaml
@@ -1,0 +1,49 @@
+apiVersion: metering.openshift.io/v1
+kind: MeteringConfig
+metadata:
+  name: operator-metering
+  namespace: openshift-metering
+spec:
+  permissions:
+    meteringAdmins:
+      - kind: Group
+        name: metering-admins
+    meteringViewers:
+      - kind: Group
+        name: metering-viewers
+    reportExporters:
+      - kind: Group
+        name: cluster-admins
+      - kind: User
+        name: bob-from-accounting
+    reporting-operator:
+      spec:
+        authProxy:
+          htpasswd:
+            data: |
+              testuser:{SHA}y/2sYAj5yrQIN4TL0YdPdmGNKpc=
+    reportingAdmins:
+      - kind: ServiceAccount
+        name: default
+        namespace: my-custom-ns
+    reportingViewers:
+      - kind: Group
+        name: reporting-readers
+  presto:
+    spec:
+      coordinator:
+        resources:
+          limits:
+            cpu: 3
+            memory: 5Gi
+          requests:
+            cpu: 1.5
+            memory: 3Gi
+  storage:
+    hive:
+      sharedPVC:
+        claimName: metering-nfs
+        createPVC: true
+        size: 10Gi
+      type: sharedPVC
+    type: hive


### PR DESCRIPTION
This file contains metering-configuration-auth-role-binding, this will help the users with four roles
```bash report-exporter
reporting-admin
reporting-viewer
metering-admin
metering-viewer

YAML template also contains storage spec and presto spec to bring the metering components on the CRC Cluster 